### PR TITLE
[FEATURE] modified date when updating a published article

### DIFF
--- a/superdesk/metadata/item.py
+++ b/superdesk/metadata/item.py
@@ -541,6 +541,12 @@ metadata_schema = {
             'marked_for_sms': {
                 'type': 'boolean',
                 'default': False
+            },
+            'change_types': {
+                'type': 'string'
+            },
+            'change_types_tmp': {
+                'type': 'string'
             }
         }
     },

--- a/superdesk/publish/formatters/ninjs_formatter.py
+++ b/superdesk/publish/formatters/ninjs_formatter.py
@@ -33,6 +33,7 @@ import json
 import superdesk
 import logging
 import re
+from datetime import datetime
 
 from eve.utils import config
 from superdesk.publish.formatters import Formatter
@@ -246,6 +247,10 @@ class NINJSFormatter(Formatter):
 
         if article.get('authors'):
             ninjs['authors'] = self._format_authors(article)
+
+        if article.get('flags', {}).get('change_types_tmp') == "2":
+            update_date = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+            ninjs["extra"].update({"update_date": update_date})
 
         if (article.get('schedule_settings') or {}).get('utc_publish_schedule'):
             ninjs['publish_schedule'] = article['schedule_settings']['utc_publish_schedule']


### PR DESCRIPTION
We have two versions for updating a published article.
1) only some grammar corrections --> no republishing/ every timestamp stays the same (modified date will not be updated) no changes for date!
2) content adjustments or changes --> republishing / time stamp for modified date changes because of the new content inside the article --> also in FE there should be the modified date displayed