### PR TITLE
[ADD] new toggles in the SD editor within the info panel

### DIFF
--- a/superdesk/metadata/item.py
+++ b/superdesk/metadata/item.py
@@ -541,6 +541,22 @@ metadata_schema = {
             'marked_for_sms': {
                 'type': 'boolean',
                 'default': False
+            },
+            'advertising': {
+                'type': 'boolean',
+                'default': True
+            },
+            'noFollow': {
+                'type': 'boolean',
+                'default': False
+            },
+            'noIndex': {
+                'type': 'boolean',
+                'default': False
+            },
+            'allowComments': {
+                'type': 'boolean',
+                'default': False
             }
         }
     },

--- a/superdesk/publish/formatters/ninjs_formatter.py
+++ b/superdesk/publish/formatters/ninjs_formatter.py
@@ -247,6 +247,16 @@ class NINJSFormatter(Formatter):
         if article.get('authors'):
             ninjs['authors'] = self._format_authors(article)
 
+        if 'extra' in ninjs:
+            if article.get('flags', {}).get('advertising'):
+                ninjs["extra"].update({"advertising": True})
+            if article.get('flags', {}).get('noIndex'):
+                ninjs["extra"].update({"noIndex": True})
+            if article.get('flags', {}).get('noFollow'):
+                ninjs["extra"].update({"noFollow": True})
+            if article.get('flags', {}).get('allowComments'):
+                ninjs["extra"].update({"allowComments": True})
+
         if (article.get('schedule_settings') or {}).get('utc_publish_schedule'):
             ninjs['publish_schedule'] = article['schedule_settings']['utc_publish_schedule']
 


### PR DESCRIPTION
We need new toggles in the SD editor within the info panel.

The editors should be able to do the following settings for an article:

advertising on/ off button (slider) (default value: on)
no index/ no follow on/off button (default value: off)
allow comments: on/off button (default value: on)